### PR TITLE
feat: add cursor in search bar in Select a visualization type modal

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -441,6 +441,14 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
   const searchInputRef = useRef<HTMLInputElement>();
   const [searchInputValue, setSearchInputValue] = useState('');
   const [isSearchFocused, setIsSearchFocused] = useState(true);
+
+  // Auto-focus search input when component mounts
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+    });
+  }, []);
+  
   const isActivelySearching = isSearchFocused && !!searchInputValue;
 
   const selectedVizMetadata: ChartMetadata | null = selectedViz


### PR DESCRIPTION
### SUMMARY
Added auto-focus functionality to the search input in the visualization type selection modal. When users click "View all charts" and the "Select a visualization type" modal opens, the search input now automatically receives focus, allowing users to immediately start typing without needing to manually click on the input field first. This improves the user experience by reducing unnecessary clicks.

Technical implementation:
- Added useEffect hook in VizTypeGallery component that runs on mount to focus the search input
- Used requestAnimationFrame to ensure focus occurs after the browser's rendering cycle completes, providing smooth and reliable focusing behavior

### TESTING INSTRUCTIONS
1. Navigate to the Explore view and open any chart
2. Click the "View all charts" button (or "Change Visualization Type" button)
3. Verify that when the modal opens, the cursor automatically appears in the search input field
4. Start typing immediately without clicking - text should appear in the search box
5. Close the modal (click Cancel or X button)
6. Click "View all charts" button again to reopen the modal
7. Verify that the cursor still automatically appears in the search input on subsequent opens
8. Confirm that you can immediately type to search for visualization types without any manual clicks

Expected behavior: Search input should be focused and ready for input every time the modal opens, improving keyboard navigation and overall workflow efficiency.

### VIDEO DEMO
https://github.com/user-attachments/assets/7d9a0719-d15e-4e73-8c9c-1ee1567efa83

Fixes #4 