### PR TITLE
bug: improve isProbablyHTML function for better detection

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -54,17 +54,26 @@ export function hasHtmlTagPattern(str: string): boolean {
 export function isProbablyHTML(text: string) {
   const cleanedStr = text.trim().toLowerCase();
 
+  // Check for DOCTYPE or full HTML document structure
   if (
-    cleanedStr.startsWith('<!doctype html>') &&
-    hasHtmlTagPattern(cleanedStr)
+    cleanedStr.startsWith('<!doctype html>') ||
+    cleanedStr.startsWith('<html') ||
+    cleanedStr.startsWith('<body')
   ) {
     return true;
   }
 
   const parser = new DOMParser();
   const doc = parser.parseFromString(cleanedStr, 'text/html');
-  return Array.from(doc.body.childNodes).some(({ nodeType }) => nodeType === 1);
+  const elementNodes = Array.from(doc.body.childNodes).filter(
+    ({ nodeType }) => nodeType === 1,
+  );
+
+  // Only consider it HTML if there are multiple element nodes
+  // Single elements like <div>test</div> should be displayed as literal text
+  return elementNodes.length > 1;
 }
+
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {
   return isProbablyHTML(htmlString) ? sanitizeHtml(htmlString) : htmlString;


### PR DESCRIPTION
### SUMMARY
There is an issue in SQL Lab where query results containing strings with angle brackets appear as empty or show only the text content without the angle brackets, making it seem like data is missing. The cause is likely that isProbablyHTML function in html.tsx was too aggressive in detecting HTML. It considered any string containing a single HTML element as HTML content. When detected as HTML, the string was passed through sanitizeHtml(), then rendered using dangerouslySetInnerHTML. This caused the browser to interpret it as HTML.
To resolve this issue, the isProbablyHTML function was modified to require multiple element nodes before considering a string as HTML. This ensures that single elements are displayed as literal text and not actual HTML documents are still properly rendered when "Render HTML" is enabled.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="859" height="479" alt="Screenshot 2026-01-05 at 10 46 16 PM" src="https://github.com/user-attachments/assets/31feffe4-278c-4976-9011-0e96ae37a06b" />

After:
<img width="905" height="467" alt="Screenshot 2026-01-05 at 10 53 41 PM" src="https://github.com/user-attachments/assets/b6a0a355-048c-49f4-a7ab-51601ea2bd9d" />

### TESTING INSTRUCTIONS
Tested with several SQL query inputs to verify correct behavior. Single-element strings display as literal text instead of being rendered as HTML. Multi-element HTML renders properly as HTML when the "Render HTML" option is enabled. Strings containing comparison operators such as x < 5 and y > 3 display correctly without being misinterpreted as HTML tags.

### Video Demo:
[Video Link](https://youtu.be/8yMJ51EFrr4)

### ADDITIONAL INFORMATION
#6 