### PR TITLE
feat: update browser tab title when viewing charts in explore view to chart title

### DIFF
--- a/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/ExploreViewContainer.test.tsx
@@ -299,3 +299,26 @@ test('does omit hiddenFormData when query_mode is not enabled', async () => {
     expect(formData[key]).toBeUndefined();
   });
 });
+
+test('updates document title when chart has a name', async () => {
+  const customState = {
+    ...reduxState,
+    explore: { ...reduxState.explore, sliceName: 'My Test Chart' },
+  };
+  await waitFor(() => renderWithRouter({ initialState: customState }));
+  expect(document.title).toBe('My Test Chart');
+});
+
+test('restores original title when unmounting', async () => {
+  const originalTitle = document.title;
+  const customState = {
+    ...reduxState,
+    explore: { ...reduxState.explore, sliceName: 'Temp Chart' },
+  };
+  const { unmount } = await waitFor(() =>
+    renderWithRouter({ initialState: customState }),
+  );
+  expect(document.title).toBe('Temp Chart');
+  unmount();
+  expect(document.title).toBe(originalTitle);
+});

--- a/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
+++ b/superset-frontend/src/explore/components/ExploreViewContainer/index.jsx
@@ -71,6 +71,8 @@ import DataSourcePanel from '../DatasourcePanel';
 import ConnectedExploreChartHeader from '../ExploreChartHeader';
 import ExploreContainer from '../ExploreContainer';
 
+const originalDocumentTitle = document.title;
+
 const propTypes = {
   ...ExploreChartPanel.propTypes,
   actions: PropTypes.object.isRequired,
@@ -510,6 +512,15 @@ function ExploreViewContainer(props) {
       reRenderChart();
     }
   }, [props.ownState]);
+
+  useEffect(() => {
+    if (props.sliceName) {
+      document.title = props.sliceName;
+    }
+    return () => {
+      document.title = originalDocumentTitle;
+    };
+  }, [props.sliceName]);
 
   if (chartIsStale) {
     props.actions.logEvent(LOG_ACTIONS_CHANGE_EXPLORE_CONTROLS);


### PR DESCRIPTION
### SUMMARY
Problem
The browser tab title was not updating when navigating to charts in Explore view, unlike the Dashboard view which correctly displays dashboard names in the tab. This inconsistency made it difficult for users to identify which chart they were viewing when working with multiple tabs.

Solution
Implemented dynamic tab title updates for the Explore view by adding a useEffect hook in ExploreViewContainer/index.jsx, mirroring the existing pattern used in DashboardPage.tsx.

Implementation Details
- Pattern Used: React lifecycle cleanup pattern with useEffect
- Capture Original Title: Store the initial document.title value at module level to preserve the default "Superset" title
- Extract Chart Name: Retrieve sliceName from the Redux explore state
- Update on Mount/Change: Set document.title to the chart name when the component mounts or when sliceName changes
- Cleanup on Unmount: Return a cleanup function that restores the original title when the component unmounts or before the effect re-runs
Rationale: This approach prevents "title leaking" where the chart name would persist in the browser tab even after navigating away, ensuring proper cleanup through React's lifecycle patterns.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="701" height="365" alt="Screenshot 2025-10-31 at 2 52 21 PM" src="https://github.com/user-attachments/assets/024d7ebf-3de9-4ab1-872e-3e9e81db7ed9" />

After:
<img width="682" height="365" alt="Screenshot 2025-10-31 at 2 54 32 PM" src="https://github.com/user-attachments/assets/241155f3-8141-4859-b1a0-8bbd7b24011d" />

### VIDEO DEMO OF ISSUE FIX
[Video Link](https://youtu.be/TAISTKQ6eIk)

### TESTING INSTRUCTIONS

Manual Testing
Performed comprehensive manual testing following the provided test plan:
- Verified browser tab title updates to chart name when navigating to charts in Explore view
- Confirmed multiple tabs correctly display their respective chart names
- Verified tab title resets to "Superset" when navigating away from charts
- Tested dashboard title display and reset behavior

Automated Testing
Added two unit tests to verify document title behavior:
- Title Update Test: Validates that document.title correctly updates to the chart name when a chart with sliceName is rendered
- Cleanup Test: Ensures the original document title is properly restored when the component unmounts, preventing title pollution across navigation

Both tests use mocked Redux state and verify the title behavior at mount and unmount lifecycle stages.
Test execution: All tests pass successfully

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API




#11 