### PR TITLE
bug: Fixed bug where tags not in alphabetical order

### DIFF
--- a/superset-frontend/src/components/Tags/TagsList.tsx
+++ b/superset-frontend/src/components/Tags/TagsList.tsx
@@ -49,6 +49,15 @@ const TagsList = ({
 }: TagsListProps) => {
   const [tempMaxTags, setTempMaxTags] = useState<number | undefined>(maxTags);
 
+  // Sort tags alphabetically (case-insensitive) using memoization
+  const sortedTags = useMemo(
+    () =>
+      [...tags].sort((a, b) =>
+        a.name.toLowerCase().localeCompare(b.name.toLowerCase()),
+      ),
+    [tags],
+  );
+
   const handleDelete = (index: number) => {
     onDelete?.(index);
   };
@@ -58,21 +67,23 @@ const TagsList = ({
   const collapse = () => setTempMaxTags(maxTags);
 
   const tagsIsLong: boolean | null = useMemo(
-    () => (tempMaxTags ? tags.length > tempMaxTags : null),
-    [tags.length, tempMaxTags],
+    () => (tempMaxTags ? sortedTags.length > tempMaxTags : null),
+    [sortedTags.length, tempMaxTags],
   );
 
   const extraTags: number | null = useMemo(
     () =>
-      typeof tempMaxTags === 'number' ? tags.length - tempMaxTags + 1 : null,
-    [tagsIsLong, tags.length, tempMaxTags],
+      typeof tempMaxTags === 'number'
+        ? sortedTags.length - tempMaxTags + 1
+        : null,
+    [tagsIsLong, sortedTags.length, tempMaxTags],
   );
 
   return (
     <TagsDiv className="tag-list">
       {tagsIsLong && typeof tempMaxTags === 'number' ? (
         <>
-          {tags.slice(0, tempMaxTags - 1).map((tag: TagType, index) => (
+          {sortedTags.slice(0, tempMaxTags - 1).map((tag: TagType, index) => (
             <Tag
               id={tag.id}
               key={tag.id}
@@ -82,17 +93,17 @@ const TagsList = ({
               editable={editable}
             />
           ))}
-          {tags.length > tempMaxTags ? (
+          {sortedTags.length > tempMaxTags ? (
             <Tag
               name={`+${extraTags}...`}
               onClick={expand}
-              toolTipTitle={tags.map(t => t.name).join(', ')}
+              toolTipTitle={sortedTags.map(t => t.name).join(', ')}
             />
           ) : null}
         </>
       ) : (
         <>
-          {tags.map((tag: TagType, index) => (
+          {sortedTags.map((tag: TagType, index) => (
             <Tag
               id={tag.id}
               key={tag.id}
@@ -103,7 +114,7 @@ const TagsList = ({
             />
           ))}
           {maxTags ? (
-            tags.length > maxTags ? (
+            sortedTags.length > maxTags ? (
               <Tag name="..." onClick={collapse} />
             ) : null
           ) : null}

--- a/superset/config.py
+++ b/superset/config.py
@@ -483,7 +483,7 @@ DEFAULT_FEATURE_FLAGS: dict[str, bool] = {
     # This feature flag is used by the download feature in the dashboard view.
     # It is dependent on ENABLE_DASHBOARD_SCREENSHOT_ENDPOINT being enabled.
     "ENABLE_DASHBOARD_DOWNLOAD_WEBDRIVER_SCREENSHOT": False,
-    "TAGGING_SYSTEM": False,
+    "TAGGING_SYSTEM": True,
     "SQLLAB_BACKEND_PERSISTENCE": True,
     "LISTVIEWS_DEFAULT_CARD_VIEW": False,
     # When True, this escapes HTML (rather than rendering it) in Markdown components


### PR DESCRIPTION
### SUMMARY
Fixed inconsistent tag display order by implementing alphabetical sorting (case-insensitive) in the TagsList component. Tags now display in a consistent alphabetical order across all views (Charts, Dashboards, etc.) instead of the inconsistent order returned by the backend API. Used React's useMemo for performance optimization.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
<img width="1379" height="599" alt="Screenshot 2025-11-03 at 11 35 31 AM" src="https://github.com/user-attachments/assets/3539f81e-afc5-4796-892e-57f239612c0e" />

After:
<img width="1296" height="603" alt="Screenshot 2025-11-03 at 11 36 29 AM" src="https://github.com/user-attachments/assets/1af8aad6-3260-4ef6-9d13-bbc164197c7f" />

### VIDEO DEMO
[Video Demo Link](https://youtu.be/4xtTWyBtetI)

### TESTING INSTRUCTIONS
To manually verify the changes:
- Enable TAGGING_SYSTEM feature flag in superset/config.py
- Add multiple tags to charts/dashboards with mixed case names (e.g., "Zebra", "apple", "Banana")
- Navigate to Charts page and verify tags display alphabetically
- Navigate to Dashboards page and verify same alphabetical order
- Reload pages and confirm order remains consistent

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

#32 